### PR TITLE
General functionality

### DIFF
--- a/CodeContractsRemover.sln
+++ b/CodeContractsRemover.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.539
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.202
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeContractsRemover", "CodeContractsRemover\CodeContractsRemover.csproj", "{90B858BA-DFA8-46CC-B2D2-14CC3A01D7DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RemoveProjectProperties", "RemoveProjectProperties\RemoveProjectProperties.csproj", "{DFE4D5E1-10E2-4BFF-9243-AC11D4FCF0A5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{90B858BA-DFA8-46CC-B2D2-14CC3A01D7DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{90B858BA-DFA8-46CC-B2D2-14CC3A01D7DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{90B858BA-DFA8-46CC-B2D2-14CC3A01D7DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFE4D5E1-10E2-4BFF-9243-AC11D4FCF0A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFE4D5E1-10E2-4BFF-9243-AC11D4FCF0A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFE4D5E1-10E2-4BFF-9243-AC11D4FCF0A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFE4D5E1-10E2-4BFF-9243-AC11D4FCF0A5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RemoveProjectProperties/App.config
+++ b/RemoveProjectProperties/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+</configuration>

--- a/RemoveProjectProperties/Program.cs
+++ b/RemoveProjectProperties/Program.cs
@@ -1,0 +1,56 @@
+using Microsoft.Build.Evaluation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RemoveProjectProperties
+{
+	class Program
+	{
+		static void Main(string[] args)
+		{
+			foreach (var csprojpath in Directory.GetFiles(args[0], "*.csproj", SearchOption.AllDirectories))
+			{
+				if (csprojpath.IndexOf(@"\backup\", StringComparison.InvariantCultureIgnoreCase) >= 0
+					|| csprojpath.IndexOf(@"sql", StringComparison.InvariantCultureIgnoreCase) >= 0)
+				{
+					Console.WriteLine("Skipping {0}", Path.GetFileName(csprojpath));
+					continue;
+				}
+
+				try
+				{
+					var xf = new Project(csprojpath);
+					bool changed = false;
+					foreach (var pg in xf.Xml.PropertyGroups)
+					{
+						var propsToRemove = pg.Properties.Where(p => p.Name.StartsWith("CodeContracts")).ToArray();
+						foreach (var prop in propsToRemove)
+						{
+							changed = true;
+							pg.RemoveChild(prop);
+						}
+					}
+					if (changed)
+					{
+						xf.Xml.Save();
+						Console.WriteLine("Updated {0}", Path.GetFileName(csprojpath));
+					}
+					else
+					{
+						Console.WriteLine("NOCHNGS {0}", Path.GetFileName(csprojpath));
+					}
+				}
+				catch (Exception ex)
+				{
+					Console.WriteLine("ERROR   {0}", Path.GetFileName(csprojpath));
+				}
+			}
+			Console.WriteLine("Done.");
+			Console.ReadLine();
+		}
+	}
+}

--- a/RemoveProjectProperties/Properties/AssemblyInfo.cs
+++ b/RemoveProjectProperties/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RemoveProjectProperties")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("RemoveProjectProperties")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("dfe4d5e1-10e2-4bff-9243-ac11d4fcf0a5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
- Added transformation for explicit error messages
- Changed "paramName" to nameof(paramName)
- Fixed code generation for if (foo) { throw; } to use whitespace over multiple lines
- Added code to preserve comments prefixing Requires
- Bugfix for using statements not present inside of namespace causing `System.ArugmentException` instead of `ArgumentException`
- Added support for negation so that crsn is handled cleanly (`Contract.Requires(!string.IsNullOrWhitespace(foo))` becomes `if (string.IsNullOrWhitespace`)
- Disabled transformations of comparison operators to compensate for non-commutable operator pairs
- Added tool to remove dead properties from csproj files.