### PR TITLE
Show "$result" instead of Contract.Result in messages and some other improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To run using [mono](http://www.mono-project.com/download/#download-lin) on Linux
 #### Mode - Convert
 - Converts all [Contract.Requires](https://msdn.microsoft.com/en-us/library/system.diagnostics.contracts.contract.requires(v=vs.110).aspx) to "if(!x) throw new ArgumentException()" pattern at the beginning of method/property/constructor.
 - Converts all [Contract.Ensures](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.contract.ensures?view=netcore-3.1) to "if(!x) throw new InvalidOperationException()" pattern before each return incide method/property/constructor.
-- Converts all [Contract.Assert](https://msdn.microsoft.com/en-us/library/system.diagnostics.contracts.contract.assert(v=vs.110).aspx) and [Contract.Assume](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.contract.assume?view=netcore-3.1) to "if(!x) throw new ArgumentException()" pattern.
+- Converts all [Contract.Assert](https://msdn.microsoft.com/en-us/library/system.diagnostics.contracts.contract.assert(v=vs.110).aspx), [Contract.Assume](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.contract.assume?view=netcore-3.1) and [Contract.Invariant](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.contract.invariant?view=netcore-3.1) to "if(!x) throw new InvalidOperationException()" pattern.
 - Invokes invariant methods before each return incide method/property/constructor.
 - Preserves all other [Contract](https://msdn.microsoft.com/en-us/library/system.diagnostics.contracts.contract(v=vs.110).aspx) invocations (including Attributes and Contract classes).
 - Removes CodeContract properties and constants from project files

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To run using [mono](http://www.mono-project.com/download/#download-lin) on Linux
 
 #### Mode - Convert
 - Converts all [Contract.Requires](https://msdn.microsoft.com/en-us/library/system.diagnostics.contracts.contract.requires(v=vs.110).aspx) to "if(!x) throw new ArgumentException()" pattern at the beginning of method/property/constructor.
-- Converts all [Contract.Ensures](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.contract.ensures?view=netcore-3.1) to "if(!x) throw new InvalidOperationException()" pattern before each return incide method/property/constructor.
+- Converts all [Contract.Ensures](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.contract.ensures?view=netcore-3.1) to "if(!x) throw new InvalidOperationException()" pattern before each return inside method/property/constructor.
 - Converts all [Contract.Assert](https://msdn.microsoft.com/en-us/library/system.diagnostics.contracts.contract.assert(v=vs.110).aspx), [Contract.Assume](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.contract.assume?view=netcore-3.1) and [Contract.Invariant](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.contracts.contract.invariant?view=netcore-3.1) to "if(!x) throw new InvalidOperationException()" pattern.
 - Invokes invariant methods before each return incide method/property/constructor.
 - Preserves all other [Contract](https://msdn.microsoft.com/en-us/library/system.diagnostics.contracts.contract(v=vs.110).aspx) invocations (including Attributes and Contract classes).

--- a/src/CodeContractsRemoverTests/ContractRemoverTests.Process_ConvertMode_ResultIsCorrect.approved.cs
+++ b/src/CodeContractsRemoverTests/ContractRemoverTests.Process_ConvertMode_ResultIsCorrect.approved.cs
@@ -16,7 +16,7 @@ namespace Tests
 
 		public static Utils(int i)
 		{
-			if (!(i > 0)) throw new ArgumentOutOfRangeException(nameof(i), "Contract assertion not met: i > 0");
+			if (!(i > 0)) throw new ArgumentOutOfRangeException(nameof(i), $"Contract assertion not met: {nameof(i)} > 0");
 
 			_i = i;
 		    CheckStaticInvariants();
@@ -27,13 +27,13 @@ namespace Tests
 		{
 			set
 			{
-				if (!(value > 0)) throw new ArgumentOutOfRangeException(nameof(value), "Contract assertion not met: value > 0");
+				if (!(value > 0)) throw new ArgumentOutOfRangeException(nameof(value), $"Contract assertion not met: {nameof(value)} > 0");
 				_i = value;
 			    CheckInvariants();
 			}
 			get
 			{
-			    if (!(_i > 0)) throw new InvalidOperationException("Contract assertion not met: Contract.Result<int>() > 0");
+			    if (!(_i > 0)) throw new InvalidOperationException($"Contract assertion not met: $result > 0");
 			    CheckInvariants();
 			    return _i;
 			}
@@ -45,7 +45,7 @@ namespace Tests
 	        get
 	        {
 	            var result = "x";
-	            if (result == null) throw new InvalidOperationException("Contract assertion not met: Contract.Result<string>() != null");
+	            if (result == null) throw new InvalidOperationException($"Contract assertion not met: $result != null");
 	            CheckInvariants();
 	            return result;
 	        }
@@ -53,14 +53,14 @@ namespace Tests
 
 		public static Task FaultedTask([NotNull] Exception error)
 		{
-			if (error == null) throw new ArgumentNullException(nameof(error), "Contract assertion not met: error != null");
-			if (error == null) throw new ArgumentNullException(nameof(error), "Contract assertion not met: error != null");
+			if (error == null) throw new ArgumentNullException(nameof(error), $"Contract assertion not met: {nameof(error)} != null");
+			if (error == null) throw new InvalidOperationException($"Contract assertion not met: {nameof(error)} != null");
 
 			var x = 1;
 			if (x == 1)
 			{
 			    var result = FaultedTask<object>(error);
-			    if (result == null) throw new InvalidOperationException("Contract assertion not met: Contract.Result<Task>() != null");
+			    if (result == null) throw new InvalidOperationException($"Contract assertion not met: $result != null");
 			    CheckStaticInvariants();
 			    return result;
 			}
@@ -68,7 +68,7 @@ namespace Tests
 			{
 				{
 				    var result = FaultedTask<object>(error);
-				    if (result == null) throw new InvalidOperationException("Contract assertion not met: Contract.Result<Task>() != null");
+				    if (result == null) throw new InvalidOperationException($"Contract assertion not met: $result != null");
 				    CheckStaticInvariants();
 				    return result;
 				}
@@ -76,7 +76,7 @@ namespace Tests
 			else
 			{
 			    var result = null;
-			    if (result == null) throw new InvalidOperationException("Contract assertion not met: Contract.Result<Task>() != null");
+			    if (result == null) throw new InvalidOperationException($"Contract assertion not met: $result != null");
 			    CheckStaticInvariants();
 			    return result;
 			}
@@ -84,7 +84,7 @@ namespace Tests
 
 		public static Task FaultedTask2([NotNull] Exception error)
 		{
-			if (error == null) throw new ArgumentNullException(nameof(error), "Contract assertion not met: error != null");
+			if (error == null) throw new ArgumentNullException(nameof(error), $"Contract assertion not met: {nameof(error)} != null");
 
 		    var result = FaultedTask<object>(error);
 		    CheckStaticInvariants();
@@ -96,7 +96,7 @@ namespace Tests
 			var x = 1;
 
 		    var result = FaultedTask<object>(error);
-		    if (result == null) throw new InvalidOperationException("Contract assertion not met: Contract.Result<Task>() != null");
+		    if (result == null) throw new InvalidOperationException($"Contract assertion not met: $result != null");
 		    CheckStaticInvariants();
 		    return result;
 		}
@@ -107,7 +107,7 @@ namespace Tests
 
 			var rrr = FaultedTask<object>(error);
 
-		    if (rrr == null) throw new InvalidOperationException("Contract assertion not met: Contract.Result<Task>() != null");
+		    if (rrr == null) throw new InvalidOperationException($"Contract assertion not met: $result != null");
 		    CheckStaticInvariants();
 		    return rrr;
 		}
@@ -130,15 +130,15 @@ namespace Tests
 
 		public void VoidMethod([NotNull] string par)
 		{
-			if (par == null) throw new ArgumentNullException(nameof(par), "Contract assertion not met: par != null");
+			if (par == null) throw new ArgumentNullException(nameof(par), $"Contract assertion not met: {nameof(par)} != null");
 			var x = 1;
 			if (x == 1)
 			{
-			    if (!(_i > 10)) throw new InvalidOperationException("Contract assertion not met: _i > 10");
+			    if (!(_i > 10)) throw new InvalidOperationException($"Contract assertion not met: {nameof(_i)} > 10");
 			    CheckInvariants();
 			    return;
 			}
-		    if (!(_i > 10)) throw new InvalidOperationException("Contract assertion not met: _i > 10");
+		    if (!(_i > 10)) throw new InvalidOperationException($"Contract assertion not met: {nameof(_i)} > 10");
 		    CheckInvariants();
 		}
 
@@ -151,12 +151,12 @@ namespace Tests
 
 		private void CheckInvariants()
 		{
-			if (!(_i > 0)) throw new ArgumentOutOfRangeException("_i", "Contract assertion not met: _i > 0");
+			if (!(_i > 0)) throw new InvalidOperationException($"Contract assertion not met: {nameof(_i)} > 0");
 		}
 		
 		private static void CheckStaticInvariants()
 		{
-			if (!(stat > 0)) throw new ArgumentOutOfRangeException("stat", "Contract assertion not met: stat > 0");
+			if (!(stat > 0)) throw new InvalidOperationException($"Contract assertion not met: {nameof(stat)} > 0");
 		}
 	}
 
@@ -165,7 +165,7 @@ namespace Tests
 	{
 		public IEnumerable<CultureInfo> GetFooChain([NotNull] CultureInfo initial)
 		{
-			if (initial == null) throw new ArgumentNullException(nameof(initial), "Contract assertion not met: initial != null");
+			if (initial == null) throw new ArgumentNullException(nameof(initial), $"Contract assertion not met: {nameof(initial)} != null");
 
 			throw new NotImplementedException();
 		}

--- a/src/CodeContractsRemoverTests/ContractRemoverTests.Process_ExtensionsCase_ResultIsCorrect.approved.cs
+++ b/src/CodeContractsRemoverTests/ContractRemoverTests.Process_ExtensionsCase_ResultIsCorrect.approved.cs
@@ -6,7 +6,7 @@ namespace Test
 	{
 		public static string AsString([NotNull] this string value)
 		{
-			if (value == null) throw new System.ArgumentNullException(nameof(value), "Contract assertion not met: value != null");
+			if (value == null) throw new System.ArgumentNullException(nameof(value), $"Contract assertion not met: {nameof(value)} != null");
 			return value;
 		}
 	}

--- a/src/CodeContractsRemoverTests/ContractRemoverTests.Process_FileWithLeadingComments_LeadingCommentsArePreserved.approved.cs
+++ b/src/CodeContractsRemoverTests/ContractRemoverTests.Process_FileWithLeadingComments_LeadingCommentsArePreserved.approved.cs
@@ -26,7 +26,7 @@ namespace Test
 		[global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
 		internal void Ccc()
 		{
-			if (!(1 == 1)) throw new System.ArgumentException("Contract assertion not met: 1 == 1", "value");
+			if (!(1 == 1)) throw new System.InvalidOperationException($"Contract assertion not met: 1 == 1");
 		}
 
 		

--- a/src/CodeContractsRemoverTests/ContractRemoverTests.Process_StringNotNullOrEmptyCase_ResultIsCorrect.approved.cs
+++ b/src/CodeContractsRemoverTests/ContractRemoverTests.Process_StringNotNullOrEmptyCase_ResultIsCorrect.approved.cs
@@ -6,26 +6,26 @@ namespace Test
 	{
 		public static string AsString([NotNull] this string value)
 		{
-			if (string.IsNullOrEmpty(value)) throw new System.ArgumentException("Contract assertion not met: !string.IsNullOrEmpty(value)", nameof(value));
+			if (string.IsNullOrEmpty(value)) throw new System.ArgumentException($"Contract assertion not met: !string.IsNullOrEmpty({nameof(value)})", nameof(value));
 			return value;
 		}
 
 		public static string AsString2(this string value)
 		{
-			if (!(string.IsNullOrEmpty(value))) throw new System.ArgumentException("Contract assertion not met: string.IsNullOrEmpty(value)", nameof(value));
+			if (!(string.IsNullOrEmpty(value))) throw new System.ArgumentException($"Contract assertion not met: string.IsNullOrEmpty({nameof(value)})", nameof(value));
 			return value;
 		}
 
 		[NotNull]
 		public static string AsString3(this string value)
 		{
-		    if (string.IsNullOrEmpty(value)) throw new System.InvalidOperationException("Contract assertion not met: !string.IsNullOrEmpty(Contract.Result<string>())");
+		    if (string.IsNullOrEmpty(value)) throw new System.InvalidOperationException($"Contract assertion not met: !string.IsNullOrEmpty($result)");
 		    return value;
 		}
 
 		public static string AsString4(this string value)
 		{
-		    if (!(string.IsNullOrEmpty(value))) throw new System.InvalidOperationException("Contract assertion not met: string.IsNullOrEmpty(Contract.Result<string>())");
+		    if (!(string.IsNullOrEmpty(value))) throw new System.InvalidOperationException($"Contract assertion not met: string.IsNullOrEmpty($result)");
 		    return value;
 		}
 	}


### PR DESCRIPTION
Show "$result" instead of Contract.Result in messages. 
Show "nameof(x)" instead of "x" in messages. 
Throw InvalidOperationException instead of ArgException in cases of Assume/Assert/Invariant